### PR TITLE
Add Flutter sample with Google Sign-In

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Aplicación de ejemplo para entrega de paquetes. La versión inicial permite iniciar
 sesión únicamente mediante Google Sign-In usando Firebase Authentication.
 
+Además, se otorgará una tarjeta electrónica de descuento: el envío número 11 será gratis.
+
 ## Estructura
 
 - `app/pubspec.yaml` – dependencias de Flutter y configuración del proyecto.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # colmena-de-ia-de-welboots-
-si nos hackeas bit me 
+
+Aplicación de ejemplo para entrega de paquetes. La versión inicial permite iniciar
+sesión únicamente mediante Google Sign-In usando Firebase Authentication.
+
+## Estructura
+
+- `app/pubspec.yaml` – dependencias de Flutter y configuración del proyecto.
+- `app/lib/main.dart` – interfaz y lógica de autenticación con Google.
+
+Para ejecutar el proyecto se requiere tener instalado [Flutter](https://flutter.dev)
+y configurar un proyecto de Firebase con autenticación de Google habilitada.
+
+```
+flutter pub get
+flutter run
+```

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EnvíaPack',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const AuthGate(),
+    );
+  }
+}
+
+class AuthGate extends StatefulWidget {
+  const AuthGate({super.key});
+
+  @override
+  State<AuthGate> createState() => _AuthGateState();
+}
+
+class _AuthGateState extends State<AuthGate> {
+  User? _user;
+  final GoogleSignIn _googleSignIn = GoogleSignIn();
+
+  Future<void> _signIn() async {
+    try {
+      final googleUser = await _googleSignIn.signIn();
+      if (googleUser == null) return; // user aborted
+
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+
+      final userCredential =
+          await FirebaseAuth.instance.signInWithCredential(credential);
+      setState(() {
+        _user = userCredential.user;
+      });
+    } catch (e) {
+      debugPrint('Error en inicio de sesión: $e');
+    }
+  }
+
+  Future<void> _signOut() async {
+    await FirebaseAuth.instance.signOut();
+    await _googleSignIn.signOut();
+    setState(() {
+      _user = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_user != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Bienvenido')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Hola, ${_user!.displayName}'),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _signOut,
+                child: const Text('Cerrar sesión'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inicia sesión')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _signIn,
+          child: const Text('Continuar con Google'),
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,12 @@
+name: entrega_paquetes
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  google_sign_in: ^6.1.5
+  firebase_auth: ^5.0.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter


### PR DESCRIPTION
## Summary
- scaffold Flutter app demonstrating Google Sign-In via Firebase
- document project layout and setup instructions

## Testing
- `flutter test` *(command failed: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_689779314c148333800d97d3c711c17e