### PR TITLE
Add Flutter sample with Google Sign-In

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # colmena-de-ia-de-welboots-
-si nos hackeas bit me 
+
+Aplicación de ejemplo para entrega de paquetes. La versión inicial permite iniciar
+sesión únicamente mediante Google Sign-In usando Firebase Authentication. Para
+utilizar Firebase es necesario inicializarlo al arrancar la app.
+
+Además, se otorgará una tarjeta electrónica de descuento: el envío número 11 será gratis.
+
+## Estructura
+
+- `app/pubspec.yaml` – dependencias de Flutter y configuración del proyecto.
+- `app/lib/main.dart` – interfaz y lógica de autenticación con Google.
+
+Para ejecutar el proyecto se requiere tener instalado [Flutter](https://flutter.dev)
+y configurar un proyecto de Firebase con autenticación de Google habilitada.
+Las dependencias principales incluyen `google_sign_in`, `firebase_auth` y
+`firebase_core`.
+
+```
+flutter pub get
+flutter run
+```
+
+## Vista rápida del código
+
+El archivo `app/lib/main.dart` maneja el flujo de autenticación con Google y
+muestra el nombre del usuario cuando la sesión se inicia correctamente:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+// ... resto del código de la interfaz y autenticación
+```
+
+## Publicación en tiendas
+
+### Android (Google Play)
+1. Genera un keystore de subida:
+   ```bash
+   keytool -genkey -v -keystore android/app/upload-keystore.jks \
+     -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+   ```
+2. Configura las credenciales en `android/key.properties`.
+3. Compila el paquete de lanzamiento:
+   ```bash
+   flutter build appbundle --release
+   ```
+4. Sube el archivo `.aab` generado a [Google Play Console](https://play.google.com/console).
+
+### iOS (App Store)
+1. Inscríbete en el [Apple Developer Program](https://developer.apple.com/programs/) y
+   crea certificados, perfiles de distribución y un *bundle identifier*.
+2. En macOS con Xcode instalado, compila el binario:
+   ```bash
+   flutter build ipa --release
+   ```
+3. Sube el `.ipa` mediante la app **Transporter** o `xcrun altool` a
+   [App Store Connect](https://appstoreconnect.apple.com).
+4. Completa los metadatos y envía la versión a revisión.

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EnvíaPack',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const AuthGate(),
+    );
+  }
+}
+
+class AuthGate extends StatefulWidget {
+  const AuthGate({super.key});
+
+  @override
+  State<AuthGate> createState() => _AuthGateState();
+}
+
+class _AuthGateState extends State<AuthGate> {
+  User? _user;
+  final GoogleSignIn _googleSignIn = GoogleSignIn();
+
+  Future<void> _signIn() async {
+    try {
+      final googleUser = await _googleSignIn.signIn();
+      if (googleUser == null) return; // user aborted
+
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+
+      final userCredential =
+          await FirebaseAuth.instance.signInWithCredential(credential);
+      setState(() {
+        _user = userCredential.user;
+      });
+    } catch (e) {
+      debugPrint('Error en inicio de sesión: $e');
+    }
+  }
+
+  Future<void> _signOut() async {
+    await FirebaseAuth.instance.signOut();
+    await _googleSignIn.signOut();
+    setState(() {
+      _user = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_user != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Bienvenido')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Hola, ${_user!.displayName}'),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _signOut,
+                child: const Text('Cerrar sesión'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inicia sesión')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _signIn,
+          child: const Text('Continuar con Google'),
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,13 @@
+name: entrega_paquetes
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  google_sign_in: ^6.1.5
+  firebase_auth: ^5.0.0
+  firebase_core: ^3.0.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter


### PR DESCRIPTION
## Summary
- scaffold Flutter app demonstrating Google Sign-In via Firebase
- document project layout, setup, and publishing guide for Google Play and App Store
- note loyalty discount card in README
- initialize Firebase and add firebase_core dependency

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689779314c148333800d97d3c711c17e