### PR TITLE
Add Flutter sample with Google Sign-In and web prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,89 @@
 # colmena-de-ia-de-welboots-
-si nos hackeas bit me 
+
+Aplicación de ejemplo para entrega de paquetes. La versión inicial permite iniciar
+sesión únicamente mediante Google Sign-In usando Firebase Authentication. Para
+utilizar Firebase es necesario inicializarlo al arrancar la app.
+
+Además, se otorgará una tarjeta electrónica de descuento: el envío número 11 será gratis.
+
+## Estructura
+
+- `app/pubspec.yaml` – dependencias de Flutter y configuración del proyecto.
+- `app/lib/main.dart` – coordina la navegación según el estado de autenticación.
+- `app/lib/login_page.dart` – pantalla de inicio de sesión con Google.
+- `app/lib/home_page.dart` – pantalla mostrada tras autenticarse.
+- `web/index.html` – prototipo web con autenticación Google.
+- `web/main.js` – lógica de inicio/cierre de sesión para la versión web.
+
+Para ejecutar el proyecto se requiere tener instalado [Flutter](https://flutter.dev)
+y configurar un proyecto de Firebase con autenticación de Google habilitada.
+Las dependencias principales incluyen `google_sign_in`, `firebase_auth` y
+`firebase_core`.
+
+```
+flutter pub get
+flutter run
+```
+
+## Versión web
+
+Dentro de `web/` se incluye una adaptación mínima para navegadores.
+
+1. Reemplaza los valores de configuración en `web/main.js` con los de tu
+   proyecto de Firebase.
+2. Sirve la carpeta `web` con un servidor estático, por ejemplo:
+
+   ```bash
+   cd web
+   python -m http.server 8080
+   ```
+
+3. Abre `http://localhost:8080` en el navegador y autentícate con Google.
+
+## Vista rápida del código
+
+El archivo `app/lib/main.dart` coordina el flujo de autenticación mostrando
+`LoginPage` o `HomePage` según el estado de `FirebaseAuth`. La `LoginPage` contiene
+el botón para acceder con Google y la `HomePage` despliega el nombre del usuario
+cuando la sesión se inicia correctamente:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+// ... resto del código de la interfaz y autenticación
+```
+
+## Publicación en tiendas
+
+### Android (Google Play)
+1. Genera un keystore de subida:
+   ```bash
+   keytool -genkey -v -keystore android/app/upload-keystore.jks \
+     -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+   ```
+2. Configura las credenciales en `android/key.properties`.
+3. Compila el paquete de lanzamiento:
+   ```bash
+   flutter build appbundle --release
+   ```
+4. Sube el archivo `.aab` generado a [Google Play Console](https://play.google.com/console).
+
+### iOS (App Store)
+1. Inscríbete en el [Apple Developer Program](https://developer.apple.com/programs/) y
+   crea certificados, perfiles de distribución y un *bundle identifier*.
+2. En macOS con Xcode instalado, compila el binario:
+   ```bash
+   flutter build ipa --release
+   ```
+3. Sube el `.ipa` mediante la app **Transporter** o `xcrun altool` a
+   [App Store Connect](https://appstoreconnect.apple.com).
+4. Completa los metadatos y envía la versión a revisión.

--- a/app/lib/home_page.dart
+++ b/app/lib/home_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key, required this.user});
+
+  final User user;
+
+  Future<void> _signOut() async {
+    await FirebaseAuth.instance.signOut();
+    await GoogleSignIn().signOut();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bienvenido')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Hola, ${user.displayName}'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _signOut,
+              child: const Text('Cerrar sesión'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/login_page.dart
+++ b/app/lib/login_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  Future<void> _signIn(BuildContext context) async {
+    try {
+      final googleUser = await GoogleSignIn().signIn();
+      if (googleUser == null) return;
+
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+
+      await FirebaseAuth.instance.signInWithCredential(credential);
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error en inicio de sesión: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inicia sesión')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => _signIn(context),
+          child: const Text('Continuar con Google'),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'login_page.dart';
+import 'home_page.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EnvíaPack',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (snapshot.hasData) {
+            return HomePage(user: snapshot.data!);
+          }
+          return const LoginPage();
+        },
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,13 @@
+name: entrega_paquetes
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  google_sign_in: ^6.1.5
+  firebase_auth: ^5.0.0
+  firebase_core: ^3.0.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>EnvíaPack Web</title>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <h1>EnvíaPack Web</h1>
+    <div id="user"></div>
+    <button id="login">Iniciar sesión con Google</button>
+    <button id="logout" style="display:none">Cerrar sesión</button>
+  </body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,39 @@
+// Configuración de Firebase: sustituye los valores por los de tu proyecto.
+// TODO: rellena esta configuración.
+const firebaseConfig = {
+  apiKey: "API_KEY",
+  authDomain: "PROJECT_ID.firebaseapp.com",
+  projectId: "PROJECT_ID",
+  storageBucket: "PROJECT_ID.appspot.com",
+  messagingSenderId: "SENDER_ID",
+  appId: "APP_ID",
+};
+
+firebase.initializeApp(firebaseConfig);
+
+const auth = firebase.auth();
+const provider = new firebase.auth.GoogleAuthProvider();
+
+const loginBtn = document.getElementById('login');
+const logoutBtn = document.getElementById('logout');
+const userDiv = document.getElementById('user');
+
+loginBtn.addEventListener('click', () => {
+  auth.signInWithPopup(provider).catch(console.error);
+});
+
+logoutBtn.addEventListener('click', () => {
+  auth.signOut();
+});
+
+auth.onAuthStateChanged((user) => {
+  if (user) {
+    userDiv.textContent = `Bienvenido, ${user.displayName}`;
+    loginBtn.style.display = 'none';
+    logoutBtn.style.display = 'inline-block';
+  } else {
+    userDiv.textContent = '';
+    loginBtn.style.display = 'inline-block';
+    logoutBtn.style.display = 'none';
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold Flutter app demonstrating Google Sign-In via Firebase
- document project layout, setup, and publishing guide for Google Play and App Store
- note loyalty discount card in README
- initialize Firebase and add firebase_core dependency
- add dedicated login and home pages for Google authentication
- prototype static web version with Firebase Google Sign-In

## Testing
- `dart format app/lib/main.dart app/lib/login_page.dart app/lib/home_page.dart web/index.html web/main.js` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689779314c148333800d97d3c711c17e