### PR TITLE
Agregar script de instalación de Flutter para Linux y actualizar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ y configurar un proyecto de Firebase con autenticación de Google habilitada.
 flutter pub get
 flutter run
 ```
+
+## Instalar Flutter (Linux)
+
+Si al ejecutar ves `flutter: command not found`, instala Flutter con el script
+incluido en este repositorio:
+
+```
+bash scripts/install_flutter.sh
+source "$HOME/.bashrc"
+flutter --version
+```

--- a/scripts/install_flutter.sh
+++ b/scripts/install_flutter.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLUTTER_VERSION="${FLUTTER_VERSION:-3.29.0}"
+INSTALL_DIR="${HOME}/flutter"
+ARCHIVE_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+
+if command -v flutter >/dev/null 2>&1; then
+  echo "Flutter ya está instalado: $(flutter --version | head -n 1)"
+  exit 0
+fi
+
+mkdir -p "${HOME}"
+cd "${HOME}"
+
+echo "Descargando Flutter ${FLUTTER_VERSION}..."
+curl -fL "${ARCHIVE_URL}" -o flutter.tar.xz
+
+echo "Instalando en ${INSTALL_DIR}..."
+rm -rf "${INSTALL_DIR}"
+mkdir -p "${INSTALL_DIR}"
+tar -xJf flutter.tar.xz -C "${INSTALL_DIR}" --strip-components=1
+rm -f flutter.tar.xz
+
+if ! grep -q 'export PATH="$HOME/flutter/bin:$PATH"' "${HOME}/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/flutter/bin:$PATH"' >> "${HOME}/.bashrc"
+fi
+
+export PATH="$HOME/flutter/bin:$PATH"
+flutter --version


### PR DESCRIPTION
### Motivation

- Facilitar la puesta en marcha en entornos Linux cuando `flutter` no está instalado. 

### Description

- Añadido el script `scripts/install_flutter.sh` que descarga y instala Flutter estable por defecto (variable `FLUTTER_VERSION`) en `~/${HOME}/flutter` y añade `~/flutter/bin` al `PATH` en `~/.bashrc`.
- El script detecta una instalación existente de `flutter` y sale de forma segura si ya está disponible, y usa `curl` y `tar` para la instalación.  
- Actualizado `README.md` para documentar la nueva sección `Instalar Flutter (Linux)` y ejemplos de uso con `bash scripts/install_flutter.sh`, `source "$HOME/.bashrc"` y `flutter --version`.

### Testing

- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_689b8520ad60833391e49e7919fbf4f2)